### PR TITLE
Fix README ToC and add linter for Markdown files

### DIFF
--- a/.remarkrc.js
+++ b/.remarkrc.js
@@ -1,0 +1,5 @@
+module.exports = {
+  plugins: [
+    ['validate-links', { repository: 'opencrud/opencrud' }]
+  ]
+}

--- a/README.md
+++ b/README.md
@@ -51,36 +51,45 @@ GraphQL is a flexible query language supporting many different data access patte
 - Specs
     - SDL for data modelling: non normative
     - relational
-        - [Intro](https://github.com/opencrud/opencrud/blob/master/specs/relational/1-intro.md)
+        - [Intro][intro]
             - Areas covered
             - Focus on API, not implementation/runtime characteristics
         - Queries
-            - [Top level](https://github.com/opencrud/opencrud/blob/master/specs/relational/queries/2-1-toplevel.md)
+            - [Top level][top-level]
                 - Single fields multi fields
                 - Multi field conenctions
                 - Node field
-            - [Relations](https://github.com/opencrud/opencrud/blob/master/specs/relational/queries/2-2-relations.md)
+            - [Relations][relations]
                 - Both simple and connection
                 - Connections
                     - Aggregations
                     - Cursor
-            - [Filters](https://github.com/opencrud/opencrud/blob/master/specs/relational/queries/2-3-filters.md)
+            - [Filters][filters]
                 - Data type specific filters
                 - Single node
                 - Multi node
                 - Cross-relation filters
-            - [Aggregations](https://github.com/opencrud/opencrud/blob/master/specs/relational/queries/2-4-aggregations.md)
+            - [Aggregations][aggregations]
         - Mutations
-            - [CRUD](https://github.com/opencrud/opencrud/blob/master/specs/relational/mutations/3-1-CRUD.md)
+            - [CRUD][crud]
                 - Overview
                 - Create
                 - Update
                 - Delete
-            - [Batch mutations](https://github.com/opencrud/opencrud/blob/master/specs/relational/mutations/3-2-batch.md)
+            - [Batch mutations][batch-mutations]
                 - Overview
                 - Update
                 - Delete
-            - [Nested mutations](https://github.com/opencrud/opencrud/blob/master/specs/relational/mutations/3-3-nested.md)
+            - [Nested mutations][nested-mutations]
             - Return type
         - Subscriptions
         - Generated type names
+
+[intro]: /spec/2-relational/2-1-overview.md
+[top-level]: /spec/2-relational/2-2-queries/2-2-1-toplevel.md
+[relations]: /spec/2-relational/2-2-queries/2-2-2-relations.md
+[filters]: /spec/2-relational/2-2-queries/2-2-3-filters.md
+[aggregations]: /spec/2-relational/2-2-queries/2-2-4-aggregations.md
+[crud]: /spec/2-relational/2-3-mutations/2-3-1-crud.md
+[batch-mutations]: /spec/2-relational/2-3-mutations/2-3-2-batch.md
+[nested-mutations]: /spec/2-relational/2-3-mutations/2-3-3-nested.md

--- a/package.json
+++ b/package.json
@@ -1,11 +1,15 @@
 {
   "scripts": {
-    "test": "spec-md spec/OpenCRUD.md > /dev/null",
+    "test": "npm run lint && npm run test-spec",
+    "lint": "remark --quiet --frail .",
+    "test-spec": "spec-md spec/OpenCRUD.md > /dev/null",
     "build": "mkdir -p dist; spec-md spec/OpenCRUD.md > dist/index.html",
     "watch": "mkdir -p dist; nodemon --exec 'spec-md > dist/index.html' spec/OpenCRUD.md"
   },
   "devDependencies": {
     "nodemon": "^1.17.3",
+    "remark-cli": "^5.0.0",
+    "remark-validate-links": "^7.0.0",
     "spec-md": "^0.6.0"
   }
 }


### PR DESCRIPTION
Hey,

I have been looking on this spec considering implementing it. I found the README to be broken, as the links are pointing to non-existing files on the GitHub master branch.

Using repo-relative links allows for linting and makes sure that you can properly view a development version in other branches. Also it allows later-on usage of linting plugins to enforce a common spec style. 
I think both is crucial to further evolve the spec.

I went with declaring definitions on the bottom of the file instead of inline links, as it improves reading capabilities when you look at the pure Markdown. I have no strong feelings about this, so that could potentially be reverted.