### PR TITLE
Match type ordering

### DIFF
--- a/spec/2-relational/2-2-queries/2-2-3-filters.md
+++ b/spec/2-relational/2-2-queries/2-2-3-filters.md
@@ -63,12 +63,12 @@ type UserWhereInput {
   # DateTime field
   field: DateTime # equals
   field_not: DateTime # not equals
-  field_in: [DateTime] # in list
-  field_not_in: [DateTime] # not in list
   field_lt: DateTime # less than
   field_lte: DateTime # less then or equals
   field_gt: DateTime # greater than
   field_gte: DateTime # greater than or equals
+  field_in: [DateTime] # in list
+  field_not_in: [DateTime] # not in list
   
   # Enum field
   field: Enum # equals


### PR DESCRIPTION
The `DateTime` section is the only one that has it's `field_in` and `field_not_in` in a different order. This PR is to make it consistent with the other fields.