### PR TITLE
GraphQL field argument must be of type 'input', not 'type'

### DIFF
--- a/spec/2-relational/2-2-queries/2-2-3-filters.md
+++ b/spec/2-relational/2-2-queries/2-2-3-filters.md
@@ -16,7 +16,7 @@ OpenCRUD filters are designed to surface as many capabilities of the underlying 
 The available filters depend on the type of a field. For example an Integer field supports the greater than filter while a String field supports the contains filter that match on substrings.
 
 ```graphql
-type UserWhereInput {
+input UserWhereInput {
   AND: [UserWhereInput]
   OR: [UserWhereInput]
 


### PR DESCRIPTION
One of the example in this spec shows `UserWhereInput` which is passed as argument to queries/fields, and declared as `type`. However, GraphQL spec defines that such objects passed as arguments must be declared as `input`.
https://graphql.org/learn/schema/#input-types